### PR TITLE
VNR compatibility settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,53 @@
 {
-    "format_version": 1,
-    "header": {
-        "description": "Vanilla normals renewed PBR texture pack converted for bedrock shaders with PBR support",
-        "name": "Vanilla Normals Renuwed",
-        "uuid": "7095269e-dcac-11eb-ba80-0242ac130004",
-        "version": [1, 17, 0]
-    },
-    "modules": [
-        {
-            "description": "Vanilla normals renewed PBR texture pack converted for bedrock shaders with PBR support",
-            "type": "resources",
-            "uuid": "7b24eb8a-dcac-11eb-ba80-0242ac130004",
-            "version": [1, 17, 0]
-        }
-    ],
-    "metadata": {
-      "authors": ["Poudingue (creator)", "Jebbyk (converted)"]
-    }
+         "format_version": 1,
+         "header": {
+                  "description": "Vanilla normals renewed PBR texture pack converted for bedrock shaders with PBR support",
+                  "name": "Vanilla Normals Renuwed",
+                  "uuid": "7095269e-dcac-11eb-ba80-0242ac130004",
+                  "version": [
+                           1,
+                           17,
+                           0
+                  ]
+         },
+         "modules": [
+                  {
+                           "description": "Vanilla normals renewed PBR texture pack converted for bedrock shaders with PBR support",
+                           "type": "resources",
+                           "uuid": "7b24eb8a-dcac-11eb-ba80-0242ac130004",
+                           "version": [
+                                    1,
+                                    17,
+                                    0
+                           ]
+                  }
+         ],
+         "metadata": {
+                  "authors": [
+                           "Poudingue (creator)",
+                           "Jebbyk (converted)"
+                  ]
+         },
+         "subpacks": [
+                  {
+                           "folder_name": "atlas_32x32",
+                           "memory_tier": 0,
+                           "name": "
+
+Change this unless you have trouble with textures. If none of these options work, read §9#faq§r and if you couldn`t find your issue, then ask in §9#support§r channel.
+
+§l[Compatibility options]§r§e Atlas 32x32
+§4Close settings and restart the minecraft to apply changes!"
+                  },
+                  {
+                           "folder_name": "atlas_64x32",
+                           "memory_tier": 1,
+                           "name": "
+
+Change this unless you have trouble with textures. If none of these options work, read §9#faq§r and if you couldn`t find your issue, then ask in §9#support§r channel.
+
+§l[Compatibility options]§r§e Atlas 64x32
+§4Close settings and restart the minecraft to apply changes!"
+                  }
+         ]
 }

--- a/subpacks/atlas_32x32/shaders/glsl/includes/options/preset/other.glsl
+++ b/subpacks/atlas_32x32/shaders/glsl/includes/options/preset/other.glsl
@@ -1,0 +1,3 @@
+// this file is used to support dfifferent types fo texturepacks
+
+#define TEXTURE_ATLAS_DIMENSION vec2(32.0, 32.0) // number of rows and columns in texture atlas. most of the times it should not be changed

--- a/subpacks/atlas_32x32/shaders/glsl/includes/options/preset/other.glsl
+++ b/subpacks/atlas_32x32/shaders/glsl/includes/options/preset/other.glsl
@@ -1,3 +1,4 @@
 // this file is used to support dfifferent types fo texturepacks
 
 #define TEXTURE_ATLAS_DIMENSION vec2(32.0, 32.0) // number of rows and columns in texture atlas. most of the times it should not be changed
+#define PBR_FEATURE_ENABLED

--- a/subpacks/atlas_64x32/shaders/glsl/includes/options/preset/other.glsl
+++ b/subpacks/atlas_64x32/shaders/glsl/includes/options/preset/other.glsl
@@ -1,3 +1,4 @@
 // this file is used to support dfifferent types fo texturepacks
 
 #define TEXTURE_ATLAS_DIMENSION vec2(64.0, 32.0) // number of rows and columns in texture atlas. most of the times it should not be changed
+#define PBR_FEATURE_ENABLED

--- a/subpacks/atlas_64x32/shaders/glsl/includes/options/preset/other.glsl
+++ b/subpacks/atlas_64x32/shaders/glsl/includes/options/preset/other.glsl
@@ -1,0 +1,3 @@
+// this file is used to support dfifferent types fo texturepacks
+
+#define TEXTURE_ATLAS_DIMENSION vec2(64.0, 32.0) // number of rows and columns in texture atlas. most of the times it should not be changed


### PR DESCRIPTION
This feature were made to prevent people downloading same texture pack again just to test that it was wrong. Now they can chage texture atlas in subpack menu with nice note.
![Screenshot_20210720-231845_Minecraft](https://user-images.githubusercontent.com/56801003/126377073-da265780-a12a-4707-ba6a-4fab4338cbf7.jpg)
